### PR TITLE
Support an array of paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var array = require('cast-array')
 var Routington = require('routington')
 var assertEqual = require('assert-equal')
 
@@ -13,12 +14,16 @@ function Table () {
     match: match
   }
 
-  function add (path) {
-    assertEqual(typeof path, 'string')
+  function add (paths) {
+    paths = array(paths)
+    var key = {paths: paths}
 
-    var key = {path: path}
-    var node = router.define(path)[0]
-    node.key = key
+    paths.forEach(function (path) {
+      assertEqual(typeof path, 'string')
+
+      var node = router.define(path)[0]
+      node.key = key
+    })
 
     return key
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "dependencies": {
     "assert-equal": "~1.0.0",
+    "cast-array": "^1.0.1",
     "routington": "~1.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -5,10 +5,35 @@ var Table = require('./')
 
 test(function (t) {
   var table = Table()
-  t.deepEqual(table.add('/users/:id'), {path: '/users/:id'})
+  t.deepEqual(table.add('/users/:id'), {paths: ['/users/:id']})
   t.deepEqual(table.match('/users/123'), {
-    key: {path: '/users/:id'},
+    key: {paths: ['/users/:id']},
     params: {id: '123'}
   })
+  t.end()
+})
+
+test('multiple paths', function (t) {
+  var table = Table()
+  var paths = [
+    '/list',
+    '/list/:id/:attribute'
+  ]
+
+  var entry = table.add(paths)
+  t.deepEqual(entry, {paths: paths})
+
+  t.deepEqual(table.match('/list'), {
+    key: {paths: paths},
+    params: {}
+  }, 'first path')
+  t.deepEqual(table.match('/list/123/weight'), {
+    key: {paths: paths},
+    params: {
+      id: '123',
+      attribute: 'weight'
+    }
+  }, 'second path')
+
   t.end()
 })


### PR DESCRIPTION
Use case: one component can have multiple paths leading to it.

Example:

`/app/:listId/:detailId` => opens app at specific list and detail.

`/app` => opens app and auto-selects the list and detail ids.

In sour, ideally these two would share the same route through passing in an array of paths.
